### PR TITLE
Fix broken test with next@7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
   - "10"
   - "8"
-  - "6"
 
 notifications:
   email:

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "2.1.0",
   "description": "React server side rendering support for Fastify with Next",
   "main": "index.js",
+  "engines": {
+    "node": ">=8"
+  },
   "scripts": {
     "build": "next build",
     "build:prod": "NODE_ENV=production next build",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:prod": "NODE_ENV=production next build",
     "dev": "node example.js",
     "serve": "npm run build:prod && NODE_ENV=production node example.js",
-    "test": "npm run build && standard && NODE_ENV=production tap test.js"
+    "test": "npm run build:prod && standard && NODE_ENV=production tap test.js"
   },
   "repository": {
     "type": "git",
@@ -31,10 +31,10 @@
   "homepage": "https://github.com/fastify/fastify-react#readme",
   "dependencies": {
     "fastify-plugin": "^1.2.0",
-    "next": "^6.1.1"
+    "next": "^7.0.0"
   },
   "devDependencies": {
-    "fastify": "^1.11.0",
+    "fastify": "^1.11.2",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "standard": "^11.0.1",

--- a/test.js
+++ b/test.js
@@ -191,10 +191,10 @@ test('should throw if callback is not a function', t => {
 })
 
 test('should serve /_next/* static assets', t => {
-  t.plan(12)
+  t.plan(18)
 
   const buildId = readFileSync(join(__dirname, '.next', 'BUILD_ID'), 'utf-8')
-  const mainUrl = require('./.next/build-manifest.json')['main.js'][0]
+  const manifest = require('./.next/build-manifest.json')
 
   const fastify = Fastify()
 
@@ -204,10 +204,14 @@ test('should serve /_next/* static assets', t => {
       fastify.next('/hello')
     })
 
-  testNextAsset(t, fastify, `/_next/${buildId}/page/hello.js`)
-  testNextAsset(t, fastify, `/_next/${buildId}/page/_app.js`)
-  testNextAsset(t, fastify, `/_next/${buildId}/page/_error.js`)
-  testNextAsset(t, fastify, `/_next/${mainUrl}`)
+  const pagePrefix = `/_next/static/${buildId}/pages`
+
+  testNextAsset(t, fastify, `${pagePrefix}/hello.js`)
+  testNextAsset(t, fastify, `${pagePrefix}/_app.js`)
+  testNextAsset(t, fastify, `${pagePrefix}/_error.js`)
+
+  let commonAssets = manifest.pages['/hello']
+  commonAssets.map(suffix => testNextAsset(t, fastify, `/_next/${suffix}`))
 
   fastify.close()
 })


### PR DESCRIPTION
This is an attempt to solve failing test in #35
https://github.com/fastify/fastify-react/blob/ba3e4c7d69f5150a63ea5bb49680e6022a3651bd/test.js#L193
fails because `next@7` updated webpack from `3.x` to `4.x` which changed the generated next.js assets and their path too.

Since ef27bd9e6285638f06d2d77b7670affdf5e999b5 the plugin serves those assets with a wildcard route `/_next/*`. So the update doesn't affect the functionality and the plugin works with both `next@6` and `next@7` versions.

But running test against 2 different version of the same package feels messy (and I have no idea how to do it) that is why I simply change the test to use the new asset map. 

If you have a better approach in mind, please point to the direction, and I happy to adjust the PR. 

Edit:
`next@7` requires node >=8.x So this change would result to drop node@6 support.