### PR TITLE
Tell fastify a response was sent.

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,11 @@ function fastifyReact (fastify, options, next) {
         })
         .after(() => {
           fastify.next('/_next/*',
-            (app, req, reply) => app.handleRequest(req.req, reply.res))
+            (app, req, reply) => app.handleRequest(req.req, reply.res)
+              .then(() => {
+                reply.sent = true
+              })
+          )
         })
       next()
     })
@@ -48,6 +52,9 @@ function fastifyReact (fastify, options, next) {
       }
 
       app.render(req.raw, reply.res, path, req.query, opts.next || {})
+        .then(() => {
+          reply.sent = true
+        })
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -52,9 +52,6 @@ function fastifyReact (fastify, options, next) {
       }
 
       app.render(req.raw, reply.res, path, req.query, opts.next || {})
-        .then(() => {
-          reply.sent = true
-        })
     }
   }
 }


### PR DESCRIPTION
I noticed fastify was complaining about empty requests and non-204 codes. This patch tells fastify a response was actually sent.
